### PR TITLE
Fix currentExecution leak in CircuitBreaker

### DIFF
--- a/src/main/java/net/jodah/failsafe/CircuitBreaker.java
+++ b/src/main/java/net/jodah/failsafe/CircuitBreaker.java
@@ -312,8 +312,11 @@ public class CircuitBreaker {
   public void recordSuccess() {
     CircuitState circuitState = state.get();
     if (state != null) {
-      circuitState.recordSuccess();
-      currentExecutions.decrementAndGet();
+      try {
+        circuitState.recordSuccess();
+      } finally {
+        currentExecutions.decrementAndGet();
+      }
     }
   }
 
@@ -435,19 +438,25 @@ public class CircuitBreaker {
   void recordFailure() {
     CircuitState circuitState = state.get();
     if (state != null) {
-      circuitState.recordFailure();
-      currentExecutions.decrementAndGet();
+      try {
+        circuitState.recordFailure();
+      } finally {
+        currentExecutions.decrementAndGet();
+      }
     }
   }
 
   void recordResult(Object result, Throwable failure) {
     CircuitState circuitState = state.get();
     if (state != null) {
-      if (isFailure(result, failure))
-        circuitState.recordFailure();
-      else
-        circuitState.recordSuccess();
-      currentExecutions.decrementAndGet();
+      try {
+        if (isFailure(result, failure))
+          circuitState.recordFailure();
+        else
+          circuitState.recordSuccess();
+      } finally {
+        currentExecutions.decrementAndGet();
+      }
     }
   }
 

--- a/src/main/java/net/jodah/failsafe/internal/OpenState.java
+++ b/src/main/java/net/jodah/failsafe/internal/OpenState.java
@@ -31,11 +31,9 @@ public class OpenState implements CircuitState {
 
   @Override
   public void recordFailure() {
-    throw new IllegalStateException("Cannot record result for open circuit");
   }
 
   @Override
   public void recordSuccess() {
-    throw new IllegalStateException("Cannot record result for open circuit");
   }
 }


### PR DESCRIPTION
Fixes #32 

* Do not throw `IllegalStateException` in `recordFailure` and `recordSuccess` 
* Added `try..finally..` block to ensure currentExections get decreased in any situation.