### PR TITLE
Add Duration.equals/toString/hashCode + some simple tests for same.

### DIFF
--- a/src/main/java/net/jodah/failsafe/util/Duration.java
+++ b/src/main/java/net/jodah/failsafe/util/Duration.java
@@ -1,5 +1,6 @@
 package net.jodah.failsafe.util;
 
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -14,6 +15,23 @@ public class Duration {
   public Duration(long length, TimeUnit timeUnit) {
     this.length = length;
     this.timeUnit = timeUnit;
+  }
+
+  @Override public boolean equals(Object o)
+  {
+    return this == o 
+        || Duration.class.isInstance(o)
+           && toNanos() == Duration.class.cast(o).toNanos();
+  }
+
+  @Override public int hashCode()
+  {
+    return Objects.hash(toNanos(), TimeUnit.NANOSECONDS);
+  }
+    
+  @Override public String toString()
+  {
+    return "Duration{" + "length=" + length + ", timeUnit=" + timeUnit + '}';
   }
 
   /**

--- a/src/main/java/net/jodah/failsafe/util/Duration.java
+++ b/src/main/java/net/jodah/failsafe/util/Duration.java
@@ -1,7 +1,9 @@
 package net.jodah.failsafe.util;
 
-import java.util.Objects;
+import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
+
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 /**
  * Duration, consisting of length of a time unit.
@@ -26,9 +28,9 @@ public class Duration {
 
   @Override public int hashCode()
   {
-    return Objects.hash(toNanos(), TimeUnit.NANOSECONDS);
+    return Arrays.hashCode(new Object[] {toNanos(), NANOSECONDS});
   }
-    
+
   @Override public String toString()
   {
     return "Duration{" + "length=" + length + ", timeUnit=" + timeUnit + '}';

--- a/src/test/java/net/jodah/failsafe/util/DurationTest.java
+++ b/src/test/java/net/jodah/failsafe/util/DurationTest.java
@@ -1,0 +1,49 @@
+
+// DurationTest.java --
+//
+// DurationTest.java is part of ElectricCommander.
+//
+// Copyright (c) 2005-2016 Electric Cloud, Inc.
+// All rights reserved.
+//
+
+package net.jodah.failsafe.util;
+
+import org.testng.annotations.Test;
+
+import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static java.util.concurrent.TimeUnit.SECONDS;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+
+@Test public class DurationTest
+{
+
+    //~ Methods ----------------------------------------------------------------
+
+    public void testEquals()
+        throws Exception
+    {
+        assertEquals(new Duration(30000, MILLISECONDS),
+            new Duration(30, SECONDS));
+        assertNotEquals(new Duration(30, MILLISECONDS),
+            new Duration(30, SECONDS));
+    }
+
+    @Test public void testHashCode()
+        throws Exception
+    {
+        assertEquals(new Duration(30000, MILLISECONDS).hashCode(),
+            new Duration(30, SECONDS).hashCode());
+        assertNotEquals(new Duration(30, MILLISECONDS).hashCode(),
+            new Duration(30, SECONDS).hashCode());
+    }
+
+    @Test public void testToString()
+        throws Exception
+    {
+        assertEquals(new Duration(30, SECONDS).toString(),
+            "Duration{length=30, timeUnit=SECONDS}");
+    }
+}


### PR DESCRIPTION
I was writing some test code and realized that Duration.equals wasn't implemented, which was causing tests to fail.

NB: I chose to implement equals/hashCode so that the duration's nanosecond value is compared, e.g. 1000 MILLISECONDS is the same as 1 SECOND.