### PR TITLE
Update AbstractExecution.java

### DIFF
--- a/src/main/java/net/jodah/failsafe/AbstractExecution.java
+++ b/src/main/java/net/jodah/failsafe/AbstractExecution.java
@@ -142,7 +142,7 @@ abstract class AbstractExecution extends ExecutionContext {
     if (isAbortable)
       config.handleAbort(result, failure, this);
     else {
-      if (retriesExceeded)
+      if (!success && retriesExceeded)
         config.handleRetriesExceeded(result, failure, this);
       if (completed)
         config.handleComplete(result, failure, this, success);


### PR DESCRIPTION
If the last retry is successful, the handleRetriesExceeded gets called because the number of executions is greater than the max number of retries (i.e. it includes the first execution). I wonder if we need to check whether the result was successful or not?