### PR TITLE
Added support to easily create Proxy instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Failsafe is a lightweight, zero-dependency library for handling failures. It was
 * [Fallbacks](#fallbacks)
 * [Execution context](#execution-context)
 * [Event listeners](#event-listeners)
+* [Proxies](#proxies)
 * [Asynchronous API integration](#asynchronous-api-integration)
 * [CompletableFuture](#completablefuture-integration) and [functional interface](#functional-interface-integration) integration
 * [Execution tracking](#execution-tracking)
@@ -362,6 +363,19 @@ Failsafe.with(retryPolicy)
 
 ```java
 circuitBreaker.onOpen(() -> log.info("The circuit breaker was opened"));
+```
+
+#### Proxies
+
+Failsafe allows easily wrapping an interface with a circuit breaker and retries.
+
+Any exceptions that the underlying implementation throws that exceed the retries are thrown as-is without any wrapping.
+However if you throw a different checked exception through the use of a fallback, a *UndeclaredThrowableException* will
+be thrown that wraps the checked exception.
+
+```java
+MyInterface object = new MyImplementation();
+MyInterface proxy = Failsafe.with(retryPolicy).proxy(object, MyInterface.class);
 ```
 
 #### Asynchronous API Integration

--- a/src/main/java/net/jodah/failsafe/SyncFailsafe.java
+++ b/src/main/java/net/jodah/failsafe/SyncFailsafe.java
@@ -23,6 +23,7 @@ import net.jodah.failsafe.function.CheckedRunnable;
 import net.jodah.failsafe.function.ContextualCallable;
 import net.jodah.failsafe.function.ContextualRunnable;
 import net.jodah.failsafe.internal.util.Assert;
+import net.jodah.failsafe.proxy.FailsafeInvocationHandler;
 import net.jodah.failsafe.util.concurrent.Scheduler;
 import net.jodah.failsafe.util.concurrent.Schedulers;
 
@@ -111,6 +112,27 @@ public class SyncFailsafe<R> extends FailsafeConfig<R, SyncFailsafe<R>> {
    */
   public AsyncFailsafe<R> with(Scheduler scheduler) {
     return new AsyncFailsafe<R>(this, Assert.notNull(scheduler, "scheduler"));
+  }
+
+  /**
+   * Creates a proxy instance of the provided {@link T} instance such that all public methods
+   * use the {@link RetryPolicy} and {@link CircuitBreaker} set.
+   * The returned proxy adheres to the interface provided except for two cases:
+   * <ol>
+   *     <li>CircuitBreakerException: The methods may throw this type of
+   *     exception if the circuit breaker is open.</li>
+   *     <li>UndeclaredThrowableException: If you provide a fallback which throws
+   *     an exception undeclared by the interface.</li>
+   * </ol>
+   * @param instance the instance to wrap a proxy around
+   * @param clazz the type of the parameter needed due to erasure. This should be an interface.
+   * @param <T> the type to proxy, must be an interface.
+   * @return an object that delegates to the instance but retries
+   * @throws IllegalArgumentException if clazz is not an interface
+   *
+   */
+  public <T> T proxy(T instance, Class<T> clazz) {
+    return FailsafeInvocationHandler.retryingProxy(instance, clazz, this);
   }
 
   /**

--- a/src/main/java/net/jodah/failsafe/SyncFailsafe.java
+++ b/src/main/java/net/jodah/failsafe/SyncFailsafe.java
@@ -122,12 +122,13 @@ public class SyncFailsafe<R> extends FailsafeConfig<R, SyncFailsafe<R>> {
    *     <li>CircuitBreakerException: The methods may throw this type of
    *     exception if the circuit breaker is open.</li>
    *     <li>UndeclaredThrowableException: If you provide a fallback which throws
-   *     an exception undeclared by the interface.</li>
+   *     an exception not declared by the interface.</li>
    * </ol>
    * @param instance the instance to wrap a proxy around
-   * @param clazz the type of the parameter needed due to erasure. This should be an interface.
-   * @param <T> the type to proxy, must be an interface.
-   * @return an object that delegates to the instance but retries
+   * @param clazz the type of the parameter needed due to erasure. This must be an interface.
+   * @param <T> the type to proxy. This must be an interface.
+   * @return an object that delegates to the instance but retries and fails according to the policies configured
+   * in this {@link Failsafe instance}
    * @throws IllegalArgumentException if clazz is not an interface
    *
    */

--- a/src/main/java/net/jodah/failsafe/SyncFailsafe.java
+++ b/src/main/java/net/jodah/failsafe/SyncFailsafe.java
@@ -115,7 +115,7 @@ public class SyncFailsafe<R> extends FailsafeConfig<R, SyncFailsafe<R>> {
   }
 
   /**
-   * Creates a proxy instance of the provided {@link T} instance such that all public methods
+   * Creates a proxy instance of the provided {@link T} instance such that all methods
    * use the {@link RetryPolicy} and {@link CircuitBreaker} set.
    * The returned proxy adheres to the interface provided except for two cases:
    * <ol>

--- a/src/main/java/net/jodah/failsafe/proxy/FailsafeInvocationHandler.java
+++ b/src/main/java/net/jodah/failsafe/proxy/FailsafeInvocationHandler.java
@@ -10,7 +10,10 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 
-/** Proxy class that retries operations and has a circuit breaker. */
+/**
+ * Proxy class that retries method calls to the underlying instance
+ * under the policies and settings configured for the given {@link net.jodah.failsafe.Failsafe}.
+ */
 public class FailsafeInvocationHandler implements InvocationHandler {
 
     private final Object underlying;
@@ -54,10 +57,10 @@ public class FailsafeInvocationHandler implements InvocationHandler {
      * Unwrap the exception that Failsafe throws.
      */
     private static Throwable unwrapException(FailsafeException ex) {
-        // There are two possibly layers of indirection here.
+        // There are two possible layers of indirection here.
         //  1) Fail-safe wraps exceptions with FailsafeException
         //  2) Proxy clients use reflection to invoke methods, which wraps
-        //     exceptions in InvocationTargetExceptions.
+        //     exceptions with InvocationTargetExceptions.
         Throwable inner = ex.getCause();
         if (inner instanceof InvocationTargetException) {
             inner = inner.getCause();

--- a/src/main/java/net/jodah/failsafe/proxy/FailsafeInvocationHandler.java
+++ b/src/main/java/net/jodah/failsafe/proxy/FailsafeInvocationHandler.java
@@ -1,0 +1,68 @@
+package net.jodah.failsafe.proxy;
+
+import net.jodah.failsafe.CircuitBreaker;
+import net.jodah.failsafe.FailsafeException;
+import net.jodah.failsafe.RetryPolicy;
+import net.jodah.failsafe.SyncFailsafe;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+
+/** Proxy class that retries operations and has a circuit breaker. */
+public class FailsafeInvocationHandler implements InvocationHandler {
+
+    private final Object underlying;
+    private final SyncFailsafe<?> failsafe;
+
+    private FailsafeInvocationHandler(Object underlying, SyncFailsafe<?> failsafe) {
+        this.underlying = underlying;
+        this.failsafe = failsafe;
+    }
+
+    /**
+     * Create a Proxy around an underlying interface such that the method calls are wrapped with a
+     * {@link RetryPolicy} and a {@link CircuitBreaker}
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T retryingProxy(T instance, Class<T> clazz, SyncFailsafe<?> failsafe) {
+        if (!clazz.isInterface()) {
+            throw new IllegalArgumentException("Only interfaces are supported with default JRE proxy.");
+        }
+        return (T) Proxy.newProxyInstance(
+                clazz.getClassLoader(),
+                new Class<?>[] { clazz },
+                new FailsafeInvocationHandler(instance, failsafe));
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        return invokeWithRetry(underlying, method, args);
+    }
+
+    private Object invokeWithRetry(Object target, Method method, Object[] args)
+            throws Throwable {
+        try {
+            return failsafe.get(() -> method.invoke(target, args));
+        } catch (FailsafeException ex) {
+            throw unwrapException(ex); //unwrap FailsafeException and InvocationTargetException
+        }
+    }
+
+    /**
+     * Unwrap the exception that Failsafe throws.
+     */
+    private static Throwable unwrapException(FailsafeException ex) {
+        // There are two possibly layers of indirection here.
+        //  1) Fail-safe wraps exceptions with FailsafeException
+        //  2) Proxy clients use reflection to invoke methods, which wraps
+        //     exceptions in InvocationTargetExceptions.
+        Throwable inner = ex.getCause();
+        if (inner instanceof InvocationTargetException) {
+            inner = inner.getCause();
+        }
+        return inner;
+    }
+
+}

--- a/src/test/java/net/jodah/failsafe/examples/ProxyExample.java
+++ b/src/test/java/net/jodah/failsafe/examples/ProxyExample.java
@@ -1,0 +1,50 @@
+package net.jodah.failsafe.examples;
+
+import net.jodah.failsafe.Failsafe;
+import net.jodah.failsafe.RetryPolicy;
+
+import java.util.concurrent.atomic.AtomicLong;
+
+public class ProxyExample {
+
+    public interface Printer {
+        void print(String message);
+    }
+
+    private static class FailingSystemOutPrinter implements Printer {
+
+        private final AtomicLong count = new AtomicLong(0);
+        private long failUntil;
+
+        public FailingSystemOutPrinter(long failUntil) {
+            this.failUntil = failUntil;
+        }
+
+        @Override
+        public void print(String message) {
+            try {
+                if (count.get() < failUntil) {
+                    throw new RuntimeException(String.format("Failing %s/%s", count.get(), failUntil));
+                }
+                System.out.println(message);
+            } finally {
+                count.incrementAndGet();
+            }
+        }
+    }
+
+    public static void main(String[] args) {
+
+        Printer printer = new FailingSystemOutPrinter(1);
+        RetryPolicy retryPolicy = new RetryPolicy().withMaxRetries(2);
+
+        Printer retryingPrinter = Failsafe.with(retryPolicy)
+                .onFailedAttempt(t -> {
+                    System.out.println(t.getCause());
+                })
+                .proxy(printer, Printer.class);
+        retryingPrinter.print("Hello World");
+
+    }
+
+}

--- a/src/test/java/net/jodah/failsafe/proxy/FailsafeInvocationHandlerTest.java
+++ b/src/test/java/net/jodah/failsafe/proxy/FailsafeInvocationHandlerTest.java
@@ -1,0 +1,67 @@
+package net.jodah.failsafe.proxy;
+
+import net.jodah.failsafe.Failsafe;
+import net.jodah.failsafe.RetryPolicy;
+import org.testng.annotations.Test;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.LongAdder;
+
+import static org.testng.Assert.assertEquals;
+
+public class FailsafeInvocationHandlerTest {
+
+    interface Counter {
+
+        void increment();
+
+        long value();
+
+    }
+
+    private static class FailingCounter implements Counter {
+
+        private final AtomicLong invocations = new AtomicLong(0);
+        private final AtomicLong count = new AtomicLong(0);
+        private long failUntil;
+
+        public FailingCounter(long failUntil) {
+            this.failUntil = failUntil;
+        }
+
+        @Override
+        public void increment() {
+            try {
+                if (invocations.get() < failUntil) {
+                    throw new RuntimeException(String.format("Failing %s/%s", count.get(), failUntil));
+                }
+                count.incrementAndGet();
+            } finally {
+                invocations.incrementAndGet();
+            }
+        }
+
+        @Override
+        public long value() {
+            return count.get();
+        }
+
+    }
+
+    @Test
+    public void testSimpleProxy() {
+        FailingCounter failingCounter = new FailingCounter(1);
+        Counter counter = Failsafe.with(new RetryPolicy().withMaxRetries(3))
+                .proxy(failingCounter, Counter.class);
+        counter.increment();
+        assertEquals(counter.value(), 1L);
+        assertEquals(failingCounter.invocations.get(), 2L);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void testCreatingConcreteProxy() {
+        Failsafe.with(new RetryPolicy().withMaxRetries(3))
+                .proxy(new LongAdder(), LongAdder.class);
+    }
+
+}


### PR DESCRIPTION
It can be beneficial to wrap a whole interface easilyw ith Failsafe and
provide RetryPolicy and CircuitBreaker as a whole.

By leveraging JRE's built-in proxy construction, Failsafe can add
support for creating proxy instances for interfaces (byteBuddy and other
libraries can provide ability to create proxy classes of concrete
types).

Fixes #107 