### PR TITLE
Dynamic delay

### DIFF
--- a/src/main/java/net/jodah/failsafe/AbstractExecution.java
+++ b/src/main/java/net/jodah/failsafe/AbstractExecution.java
@@ -17,7 +17,6 @@ package net.jodah.failsafe;
 
 import java.util.concurrent.TimeUnit;
 
-import net.jodah.failsafe.function.CheckedBiFunction;
 import net.jodah.failsafe.internal.util.Assert;
 import net.jodah.failsafe.util.Duration;
 

--- a/src/main/java/net/jodah/failsafe/AbstractExecution.java
+++ b/src/main/java/net/jodah/failsafe/AbstractExecution.java
@@ -112,12 +112,13 @@ abstract class AbstractExecution extends ExecutionContext {
     if (delayFunction != null) {
         try {
             Duration dynamicDelay = delayFunction.apply(result, failure);
-            if (dynamicDelay != null && dynamicDelay.toNanos() >= 0) {
+            if (dynamicDelay != null && dynamicDelay.toNanos() >= 0)
                 delayNanos = dynamicDelay.toNanos();
-            }
         } catch (Exception ex) {
-            // Swallow all exceptions thrown while computing delay
-            // and behave as if no delay function was present.
+            if (ex instanceof RuntimeException)
+                throw (RuntimeException) ex;
+            else
+                throw new RuntimeException("unexpected exception in dynamic delay function", ex);
         }
     }
     if (delayNanos == -1)

--- a/src/main/java/net/jodah/failsafe/AbstractExecution.java
+++ b/src/main/java/net/jodah/failsafe/AbstractExecution.java
@@ -108,18 +108,11 @@ abstract class AbstractExecution extends ExecutionContext {
     }
 
     // Initialize or adjust the delay for backoffs
-    CheckedBiFunction<Object, Throwable, Duration> delayFunction = retryPolicy.getDelayFunction();
+    RetryPolicy.DelayFunction delayFunction = retryPolicy.getDelayFunction();
     if (delayFunction != null) {
-        try {
-            Duration dynamicDelay = delayFunction.apply(result, failure);
-            if (dynamicDelay != null && dynamicDelay.toNanos() >= 0)
-                delayNanos = dynamicDelay.toNanos();
-        } catch (Exception ex) {
-            if (ex instanceof RuntimeException)
-                throw (RuntimeException) ex;
-            else
-                throw new RuntimeException("unexpected exception in dynamic delay function", ex);
-        }
+        Duration dynamicDelay = delayFunction.calculateDelay(result, failure);
+        if (dynamicDelay != null && dynamicDelay.toNanos() >= 0)
+            delayNanos = dynamicDelay.toNanos();
     }
     if (delayNanos == -1)
       delayNanos = retryPolicy.getDelay().toNanos();

--- a/src/main/java/net/jodah/failsafe/RetryPolicy.java
+++ b/src/main/java/net/jodah/failsafe/RetryPolicy.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import net.jodah.failsafe.function.BiPredicate;
+import net.jodah.failsafe.function.CheckedBiFunction;
 import net.jodah.failsafe.function.Predicate;
 import net.jodah.failsafe.internal.util.Assert;
 import net.jodah.failsafe.util.Duration;
@@ -41,6 +42,7 @@ public class RetryPolicy {
 
   private Duration delay;
   private double delayFactor;
+  private CheckedBiFunction<Object, Throwable, Duration> delayFunction;
   private Duration jitter;
   private double jitterFactor;
   private Duration maxDelay;
@@ -224,6 +226,14 @@ public class RetryPolicy {
    */
   public Duration getDelay() {
     return delay;
+  }
+
+  /**
+   * Returns the function that determines the next delay given
+   * a failed attempt with the given {@link Throwable}.
+   */
+  public CheckedBiFunction<Object, Throwable, Duration> getDelayFunction() {
+    return delayFunction;
   }
 
   /**
@@ -417,6 +427,20 @@ public class RetryPolicy {
         "delay must be less than the maxDuration");
     Assert.state(maxDelay == null, "Backoff delays have already been set");
     this.delay = new Duration(delay, timeUnit);
+    return this;
+  }
+
+  /**
+   * Sets the function that determines the next delay before retrying.
+   *
+   * @throws NullPointerException if {@code d} is null
+   * @throws IllegalArgumentException if {@code delay} <= 0
+   * @throws IllegalStateException if {@code delay} is >= the {@link RetryPolicy#withMaxDuration(long, TimeUnit)
+   *           maxDuration}
+   */
+  public RetryPolicy withDelayFunction(CheckedBiFunction<Object, Throwable, Duration> delayFunction) {
+    Assert.notNull(delayFunction, "delayFunction");
+    this.delayFunction = delayFunction;
     return this;
   }
 

--- a/src/main/java/net/jodah/failsafe/RetryPolicy.java
+++ b/src/main/java/net/jodah/failsafe/RetryPolicy.java
@@ -21,7 +21,6 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import net.jodah.failsafe.function.BiPredicate;
-import net.jodah.failsafe.function.CheckedBiFunction;
 import net.jodah.failsafe.function.Predicate;
 import net.jodah.failsafe.internal.util.Assert;
 import net.jodah.failsafe.util.Duration;
@@ -38,11 +37,16 @@ import net.jodah.failsafe.util.Duration;
  * @author Jonathan Halterman
  */
 public class RetryPolicy {
+  @FunctionalInterface
+  public interface DelayFunction {
+      Duration calculateDelay(Object result, Throwable exception);
+  }
+
   static final RetryPolicy NEVER = new RetryPolicy().withMaxRetries(0);
 
   private Duration delay;
   private double delayFactor;
-  private CheckedBiFunction<Object, Throwable, Duration> delayFunction;
+  private DelayFunction delayFunction;
   private Duration jitter;
   private double jitterFactor;
   private Duration maxDelay;
@@ -232,7 +236,7 @@ public class RetryPolicy {
    * Returns the function that determines the next delay given
    * a failed attempt with the given {@link Throwable}.
    */
-  public CheckedBiFunction<Object, Throwable, Duration> getDelayFunction() {
+  public DelayFunction getDelayFunction() {
     return delayFunction;
   }
 
@@ -433,12 +437,9 @@ public class RetryPolicy {
   /**
    * Sets the function that determines the next delay before retrying.
    *
-   * @throws NullPointerException if {@code d} is null
-   * @throws IllegalArgumentException if {@code delay} <= 0
-   * @throws IllegalStateException if {@code delay} is >= the {@link RetryPolicy#withMaxDuration(long, TimeUnit)
-   *           maxDuration}
+   * @throws NullPointerException if {@code delayFunction} is null
    */
-  public RetryPolicy withDelayFunction(CheckedBiFunction<Object, Throwable, Duration> delayFunction) {
+  public RetryPolicy withDelayFunction(DelayFunction delayFunction) {
     Assert.notNull(delayFunction, "delayFunction");
     this.delayFunction = delayFunction;
     return this;

--- a/src/main/java/net/jodah/failsafe/RetryPolicy.java
+++ b/src/main/java/net/jodah/failsafe/RetryPolicy.java
@@ -484,28 +484,6 @@ public class RetryPolicy {
    * Sets the function that determines the next delay before retrying.
    * @param delayFunction the function to use to compute the delay before a next attempt
    * @param resultType the type of result from the previous attempt expected by the delay function
-   * @throws NullPointerException if {@code delayFunction} is null or {@code resultType} is null
-   * @throws IllegalStateException if backoff delays have already been set
-   */
-  public <R> RetryPolicy withDelay(DelayFunction<R, Throwable> delayFunction, Class<R> resultType) {
-      return withDelay(delayFunction, resultType, Throwable.class);
-  }
-
-  /**
-   * Sets the function that determines the next delay before retrying.
-   * @param delayFunction the function to use to compute the delay before a next attempt
-   * @param failureType the type of failure from the previous attempt expected by the delay function
-   * @throws NullPointerException if {@code delayFunction} is null or {@code failureType} is null
-   * @throws IllegalStateException if backoff delays have already been set
-   */
-  public <F extends Throwable> RetryPolicy withDelayThrowing(DelayFunction<Object, F> delayFunction, Class<F> failureType) {
-      return withDelay(delayFunction, Object.class, failureType);
-  }
-
-  /**
-   * Sets the function that determines the next delay before retrying.
-   * @param delayFunction the function to use to compute the delay before a next attempt
-   * @param resultType the type of result from the previous attempt expected by the delay function
    * @param failureType the type of failure from the previous attempt expected by the delay function
    * @throws NullPointerException if {@code delayFunction} is null, {@code resultType} is null, or
    *     {@code failureType} is null

--- a/src/test/java/net/jodah/failsafe/DynamicDelayTest.java
+++ b/src/test/java/net/jodah/failsafe/DynamicDelayTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package net.jodah.failsafe;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import java.util.concurrent.TimeUnit;
+
+import net.jodah.failsafe.util.Duration;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class DynamicDelayTest {
+
+    static class DynamicDelayException extends Exception {
+        final Duration duration;
+
+        DynamicDelayException(long time, TimeUnit unit) {
+            super(String.format("Dynamic delay of %s %s", time, unit));
+            this.duration = new Duration(time, unit);
+        }
+
+        public Duration getDuration() {
+            return duration;
+        }
+    }
+
+    @Test
+    public void testDynamicDelay() {
+        long DELAY = TimeUnit.MILLISECONDS.toNanos(500);
+        long PAD = TimeUnit.MILLISECONDS.toNanos(25);
+
+        RetryPolicy retryPolicy = new RetryPolicy()
+            .withDelayFunction((result, exception) -> {
+                if (exception instanceof DynamicDelayException)
+                    return ((DynamicDelayException) exception).getDuration();
+                else
+                    return null;
+            })
+            .withMaxRetries(2);
+
+        List<Long> executionTimes = new ArrayList<>();
+
+        Failsafe.with(retryPolicy)
+            .run((ExecutionContext context) -> {
+                executionTimes.add(System.nanoTime());
+                if (context.getExecutions() == 0)
+                    throw new DynamicDelayException(DELAY, TimeUnit.NANOSECONDS);
+            });
+
+        assertEquals(executionTimes.size(), 2, "Should have exactly two executions");
+        long t0 = executionTimes.get(0);
+        long t1 = executionTimes.get(1);
+        //System.out.printf("actual delay %d, expected %d%n",
+        //    TimeUnit.NANOSECONDS.toMillis(t1 - t0),
+        //    TimeUnit.NANOSECONDS.toMillis(DELAY));
+        assertTrue(t1 - t0 > DELAY - PAD, "Time between executions less than expected");
+        assertTrue(t1 - t0 < DELAY + PAD, "Time between executions more than expected");
+    }
+}

--- a/src/test/java/net/jodah/failsafe/dyndelay/DynamicDelayTest.java
+++ b/src/test/java/net/jodah/failsafe/dyndelay/DynamicDelayTest.java
@@ -49,9 +49,6 @@ public class DynamicDelayTest {
     static class UncheckedExpectedException extends RuntimeException {
     }
 
-    static class CheckedExpectedException extends Exception {
-    }
-
 
     @Test(expectedExceptions = NullPointerException.class)
     public void testNullDelayFunction() {
@@ -108,24 +105,5 @@ public class DynamicDelayTest {
             .run((ExecutionContext context) -> {
                 throw new RuntimeException("try again");
             });
-    }
-
-
-    @Test
-    public void testCheckedExceptionComputingDelay() {
-        RetryPolicy retryPolicy = new RetryPolicy()
-            .withDelayFunction((result, exception) -> {
-                throw new CheckedExpectedException();
-            });
-
-        try {
-            Failsafe.with(retryPolicy)
-                .run((ExecutionContext context) -> {
-                    throw new RuntimeException("try again");
-                });
-            fail("Expecting wrapped checked exception to be thrown");
-        } catch (RuntimeException ex) {
-            assertTrue(ex.getCause() instanceof CheckedExpectedException);
-        }
     }
 }

--- a/src/test/java/net/jodah/failsafe/dyndelay/DynamicDelayTest.java
+++ b/src/test/java/net/jodah/failsafe/dyndelay/DynamicDelayTest.java
@@ -13,13 +13,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License
  */
-package net.jodah.failsafe;
+package net.jodah.failsafe.dyndelay;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import java.util.concurrent.TimeUnit;
 
+import net.jodah.failsafe.ExecutionContext;
+import net.jodah.failsafe.Failsafe;
+import net.jodah.failsafe.RetryPolicy;
 import net.jodah.failsafe.util.Duration;
 
 import org.testng.annotations.Test;


### PR DESCRIPTION
This PR is in response to #110. It adds a delay function property to RetryPolicy that is used, if set, to compute the next delay from the previous result or exception.

There are some awkward bits here:

- I used `net.jodah.failsafe.util.Duration` in signature of the delay function, though
  I really wanted to use `java.time.Duration`.
- Combining delay factor other than 1 with delay function would be meaningless, but
  I've done nothing to make them mutually exclusive.
- The one included test is pretty crude, passing if the actual delay is within a window of the
  requested delay.

