### PR TITLE
Support CompletionStage instead of CompletableFuture in AsyncFailsafe…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,3 @@ target/
 .settings/
 test-output/
 docs/
-
-*.iml
-.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ target/
 .settings/
 test-output/
 docs/
+
+*.iml
+.idea/

--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ Failsafe can also perform asynchronous executions and retries on 3rd party sched
 
 #### CompletableFuture Integration
 
-Java 8 users can use Failsafe to retry [CompletableFuture] calls:
+Java 8 users can use Failsafe to retry [CompletableFuture] or [CompletionStage] calls:
 
 ```java
 Failsafe.with(retryPolicy)
@@ -494,6 +494,7 @@ Copyright 2015-2016 Jonathan Halterman and friends. Released under the [Apache 2
 [CircuitBreaker]: http://jodah.net/failsafe/javadoc/net/jodah/failsafe/CircuitBreaker.html
 
 [CompletableFuture]: https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletableFuture.html
+[CompletionStage]: https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletionStage.html 
 [ScheduledExecutorService]: https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ScheduledExecutorService.html
 [RxJava]: https://github.com/jhalterman/failsafe/blob/master/src/test/java/net/jodah/failsafe/examples/RxJavaExample.java
 [Vert.x]: https://github.com/jhalterman/failsafe/blob/master/src/test/java/net/jodah/failsafe/examples/VertxExample.java

--- a/src/main/java/net/jodah/failsafe/AsyncFailsafe.java
+++ b/src/main/java/net/jodah/failsafe/AsyncFailsafe.java
@@ -53,7 +53,7 @@ public class AsyncFailsafe<R> extends AsyncFailsafeConfig<R, AsyncFailsafe<R>> {
    * @throws NullPointerException if the {@code callable} is null
    */
   public <T> java.util.concurrent.CompletableFuture<T> future(
-      Callable<java.util.concurrent.CompletableFuture<T>> callable) {
+      Callable<? extends java.util.concurrent.CompletionStage<T>> callable) {
     return call(Functions.asyncOfFuture(callable));
   }
 
@@ -69,7 +69,7 @@ public class AsyncFailsafe<R> extends AsyncFailsafeConfig<R, AsyncFailsafe<R>> {
    * @throws NullPointerException if the {@code callable} is null
    */
   public <T> java.util.concurrent.CompletableFuture<T> future(
-      ContextualCallable<java.util.concurrent.CompletableFuture<T>> callable) {
+      ContextualCallable<? extends java.util.concurrent.CompletionStage<T>> callable) {
     return call(Functions.asyncOfFuture(callable));
   }
 
@@ -86,7 +86,7 @@ public class AsyncFailsafe<R> extends AsyncFailsafeConfig<R, AsyncFailsafe<R>> {
    * @throws NullPointerException if the {@code callable} is null
    */
   public <T> java.util.concurrent.CompletableFuture<T> futureAsync(
-      AsyncCallable<java.util.concurrent.CompletableFuture<T>> callable) {
+      AsyncCallable<? extends java.util.concurrent.CompletionStage<T>> callable) {
     return call(Functions.asyncOfFuture(callable));
   }
 

--- a/src/main/java/net/jodah/failsafe/Functions.java
+++ b/src/main/java/net/jodah/failsafe/Functions.java
@@ -158,7 +158,7 @@ final class Functions {
   }
 
   static <T> AsyncCallableWrapper<T> asyncOfFuture(
-      final AsyncCallable<java.util.concurrent.CompletableFuture<T>> callable) {
+      final AsyncCallable<? extends java.util.concurrent.CompletionStage<T>> callable) {
     Assert.notNull(callable, "callable");
     return new AsyncCallableWrapper<T>() {
       Semaphore asyncFutureLock = new Semaphore(1);
@@ -193,7 +193,7 @@ final class Functions {
     };
   }
 
-  static <T> AsyncCallableWrapper<T> asyncOfFuture(final Callable<java.util.concurrent.CompletableFuture<T>> callable) {
+  static <T> AsyncCallableWrapper<T> asyncOfFuture(final Callable<? extends java.util.concurrent.CompletionStage<T>> callable) {
     Assert.notNull(callable, "callable");
     return new AsyncCallableWrapper<T>() {
       @Override
@@ -219,7 +219,7 @@ final class Functions {
   }
 
   static <T> AsyncCallableWrapper<T> asyncOfFuture(
-      final ContextualCallable<java.util.concurrent.CompletableFuture<T>> callable) {
+      final ContextualCallable<? extends java.util.concurrent.CompletionStage<T>> callable) {
     Assert.notNull(callable, "callable");
     return new AsyncCallableWrapper<T>() {
       @Override


### PR DESCRIPTION
This is implementation for issue #117.

It changes signatures of `AsyncFailsafe` `future()` and `asyncFuture` methods to:

```
<T> java.util.concurrent.CompletableFuture<T> future(
      Callable<? extends java.util.concurrent.CompletionStage<T>> callable)

<T> java.util.concurrent.CompletableFuture<T> future(
      ContextualCallable<? extends java.util.concurrent.CompletionStage<T>> callable)

<T> java.util.concurrent.CompletableFuture<T> futureAsync(
      AsyncCallable<? extends java.util.concurrent.CompletionStage<T>> callable)
```

And also changes signatures of `Functions.asyncOfFuture(...)` methods in similar fashion.

This additional flexibility would make Failsafe library more convenient to integrate for example with Scala, where scala.compat.java8.FutureConverters methods convert scala futures to java CompletionStages (they cannot convert to CompletableFuture because of some possible race condition between scala Promise.complete and java CompletableFuture.complete methods).