### PR TITLE
Ability to reset the jitterFactor

### DIFF
--- a/src/main/java/net/jodah/failsafe/RetryPolicy.java
+++ b/src/main/java/net/jodah/failsafe/RetryPolicy.java
@@ -429,12 +429,12 @@ public class RetryPolicy {
    * Jitter should be combined with {@link #withDelay(long, TimeUnit) fixed} or
    * {@link #withBackoff(long, long, TimeUnit) exponential backoff} delays.
    * 
-   * @throws IllegalArgumentException if {@code duration} is <= 0 or > 1
+   * @throws IllegalArgumentException if {@code jitterFactor} is < 0 or > 1
    * @throws IllegalStateException if no delay has been configured or {@link #withJitter(long, TimeUnit)} has already
    *           been called
    */
   public RetryPolicy withJitter(double jitterFactor) {
-    Assert.isTrue(jitterFactor > 0 && jitterFactor <= 1, "jitterFactor must be > 0 and <= 1");
+    Assert.isTrue(jitterFactor >= 0.0 && jitterFactor <= 1.0, "jitterFactor must be >= 0 and <= 1");
     Assert.state(delay != null, "A fixed or exponential backoff delay must be configured");
     Assert.state(jitter == null, "withJitter(long, timeUnit) has already been called");
     this.jitterFactor = jitterFactor;


### PR DESCRIPTION
Hi all,

We would like to pass arguments from our config to the `RetryPolicy`. By default there is not `jitterFactor`, so we initialise the `RetryPolicy` by passing `0.0`, but this raises an exception. It would be great if the library would just accept this default value. This can also come in handy if you want to disable the `withJitter(double)` later on, because you want to set a `withJitter(long, TimeUnit)`.

Cheers, Fokko