### PR TITLE
Enable standalone circuitbreaker usage

### DIFF
--- a/src/main/java/net/jodah/failsafe/CircuitBreaker.java
+++ b/src/main/java/net/jodah/failsafe/CircuitBreaker.java
@@ -425,7 +425,10 @@ public class CircuitBreaker {
     return this;
   }
 
-  void before() {
+  /**
+   * Increase execution counter.
+  */
+  public void before() {
     currentExecutions.incrementAndGet();
   }
 


### PR DESCRIPTION
Change method before to be public. Necessary for standalone usage of circuitbreaker.

Fixes #51 