### PR TITLE
Handle completed futures

### DIFF
--- a/src/main/java/net/jodah/failsafe/Functions.java
+++ b/src/main/java/net/jodah/failsafe/Functions.java
@@ -192,9 +192,15 @@ final class Functions {
         execution.preExecute();
         supplier.get().whenComplete((innerResult, failure) -> {
           // Unwrap CompletionException cause
-          ExecutionResult result = failure instanceof CompletionException ?
-              ExecutionResult.failure(failure.getCause()) :
-              ExecutionResult.success(innerResult);
+          ExecutionResult result;
+          if ( failure != null ) {
+            if ( failure instanceof CompletionException) {
+              failure = failure.getCause();
+            }
+            result = ExecutionResult.failure(failure);
+          } else {
+            result = ExecutionResult.success(innerResult);
+          }
           execution.record(result);
           promise.complete(result);
         });
@@ -216,9 +222,15 @@ final class Functions {
         execution.preExecute();
         supplier.get(execution).whenComplete((innerResult, failure) -> {
           // Unwrap CompletionException cause
-          ExecutionResult result = failure instanceof CompletionException ?
-              ExecutionResult.failure(failure.getCause()) :
-              ExecutionResult.success(innerResult);
+          ExecutionResult result;
+          if ( failure != null ) {
+            if ( failure instanceof CompletionException) {
+              failure = failure.getCause();
+            }
+            result = ExecutionResult.failure(failure);
+          } else {
+            result = ExecutionResult.success(innerResult);
+          }
           execution.record(result);
           promise.complete(result);
         });

--- a/src/test/java/net/jodah/failsafe/AsyncFailsafeTest.java
+++ b/src/test/java/net/jodah/failsafe/AsyncFailsafeTest.java
@@ -341,6 +341,22 @@ public class AsyncFailsafeTest extends AbstractFailsafeTest {
   }
 
   /**
+   * Assert handles a supplier that returns an exceptionally completed future.
+   */
+  public void shouldHandleCompletedExceptionallyGetStageAsync() {
+    CompletableFuture<Boolean> failedFuture = new CompletableFuture<>();
+    failedFuture.completeExceptionally(new IllegalArgumentException());
+    assertThrows(() -> Failsafe.with(retryTwice).getStageAsync(() -> failedFuture).get(),
+            ExecutionException.class, IllegalArgumentException.class);
+
+    assertThrows(() -> Failsafe.with(retryTwice).getStageAsync(context -> failedFuture).get(),
+            ExecutionException.class, IllegalArgumentException.class);
+
+    assertThrows(() -> Failsafe.with(retryTwice).getStageAsyncExecution(exec -> failedFuture).get(),
+            ExecutionException.class, IllegalArgumentException.class);
+  }
+
+  /**
    * Asserts that asynchronous completion via an execution is supported.
    */
   public void shouldCompleteAsync() throws Throwable {


### PR DESCRIPTION
If a completion stage supplier returns an exceptionally completed future, the exception in the whenComplete is not wrapped in a CompletionException, and the retry code would handle it as a success. This change would make sure that any exception is handled as an error, and still unwrap the CompletionException when needed.