### PR TITLE
chore: fix Maven warning

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
+        <version>3.1.1</version>
         <configuration>
           <archive>
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>


### PR DESCRIPTION
Maven Jar plug-in needs a version