### PR TITLE
Fix custom Executor code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ That said, it really depends on how the policies are being used, and different c
 By default, Failsafe uses the [ForkJoinPool]'s [common pool][common-pool] to perform async executions, but you can also configure a specific [ScheduledExecutorService], custom [Scheduler], or [ExecutorService] to use:
 
 ```java
-Failsafe.with(scheduler).getAsync(this::connect);
+Failsafe.with(policy).with(scheduler).getAsync(this::connect);
 ```
 
 #### Event Listeners


### PR DESCRIPTION
Hi

The method where user can pass custom Executor is available on `FailsafeExecutor` not on `Failsafe` so firstly we need to execute `with(policy)` method and then `with(executor)`. 

I fixed the code example to save a few minutes of devs guessing what's going on there ;)