### PR TITLE
Make default delay match the document comment

### DIFF
--- a/src/main/java/net/jodah/failsafe/CircuitBreaker.java
+++ b/src/main/java/net/jodah/failsafe/CircuitBreaker.java
@@ -38,7 +38,7 @@ public class CircuitBreaker<R> extends FailurePolicy<CircuitBreaker<R>, R> {
   private final AtomicReference<CircuitState> state = new AtomicReference<>();
   private final AtomicInteger currentExecutions = new AtomicInteger();
   private final CircuitBreakerStats stats = currentExecutions::get;
-  private Duration delay = Duration.ofMinutes(1);
+  private Duration delay = Duration.ZERO;
   private Duration timeout;
   private Ratio failureThreshold;
   private Ratio successThreshold;


### PR DESCRIPTION
The `getDelay()` doc-ed with `   * Returns the delay before allowing another execution on the circuit. Defaults to {@link Duration#ZERO}.` but acutally is `private Duration delay = Duration.ofMinutes(1)`