### PR TITLE
Fix doc comment

### DIFF
--- a/src/main/java/net/jodah/failsafe/CircuitBreaker.java
+++ b/src/main/java/net/jodah/failsafe/CircuitBreaker.java
@@ -81,7 +81,7 @@ public class CircuitBreaker<R> extends FailurePolicy<CircuitBreaker<R>, R> {
   }
 
   /**
-   * Returns the delay before allowing another execution on the circuit. Defaults to {@link Duration#ZERO}.
+   * Returns the delay before allowing another execution on the circuit. Defaults to 1 minute.
    *
    * @see #withDelay(Duration)
    */


### PR DESCRIPTION
The value of `delay` is set 1 minute but the doc comment is `Duration.ZERO`