### PR TITLE
PolicyListeners are not getting copied during RetryPolicy.copy()

### DIFF
--- a/src/main/java/net/jodah/failsafe/RetryPolicy.java
+++ b/src/main/java/net/jodah/failsafe/RetryPolicy.java
@@ -132,6 +132,8 @@ public class RetryPolicy<R> extends FailurePolicy<RetryPolicy<R>, R> {
     this.failedAttemptListener = rp.failedAttemptListener;
     this.retriesExceededListener = rp.retriesExceededListener;
     this.retryListener = rp.retryListener;
+    this.failureListener = rp.failureListener;
+    this.successListener = rp.successListener;
   }
 
   /**

--- a/src/test/java/net/jodah/failsafe/RetryPolicyTest.java
+++ b/src/test/java/net/jodah/failsafe/RetryPolicyTest.java
@@ -206,17 +206,22 @@ public class RetryPolicyTest {
     assertEquals(new RetryPolicy().withMaxRetries(1).getMaxAttempts(), 2);
   }
 
+  @SuppressWarnings("unchecked")
   public void testCopy() {
     RetryPolicy rp = new RetryPolicy();
     rp.withBackoff(2, 20, ChronoUnit.SECONDS, 2.5);
     rp.withMaxDuration(Duration.ofSeconds(60));
     rp.withMaxRetries(3);
+    rp.onFailure(event -> System.out.println("Failed."));
+    rp.onSuccess(event -> System.out.println("Success."));
 
     RetryPolicy rp2 = rp.copy();
-    assertEquals(rp.getDelay().toNanos(), rp2.getDelay().toNanos());
-    assertEquals(rp.getDelayFactor(), rp2.getDelayFactor());
-    assertEquals(rp.getMaxDelay().toNanos(), rp2.getMaxDelay().toNanos());
-    assertEquals(rp.getMaxDuration().toNanos(), rp2.getMaxDuration().toNanos());
-    assertEquals(rp.getMaxRetries(), rp2.getMaxRetries());
+    assertEquals(rp2.getDelay().toNanos(), rp.getDelay().toNanos());
+    assertEquals(rp2.getDelayFactor(), rp.getDelayFactor());
+    assertEquals(rp2.getMaxDelay().toNanos(), rp.getMaxDelay().toNanos());
+    assertEquals(rp2.getMaxDuration().toNanos(), rp.getMaxDuration().toNanos());
+    assertEquals(rp2.getMaxRetries(), rp.getMaxRetries());
+    assertEquals(rp2.failureListener, rp.failureListener);
+    assertEquals(rp2.successListener, rp.successListener);
   }
 }


### PR DESCRIPTION
So when `onFailed()` or `onSuccess()` are defined, and `RetryPolicy.copy()` is called,
those handlers are not getting copied over. This fixes that issue, and updates the unit test.

