### PR TITLE
Add support for CircuitBreaker.getRemainingDelay()

### DIFF
--- a/src/main/java/net/jodah/failsafe/CircuitBreaker.java
+++ b/src/main/java/net/jodah/failsafe/CircuitBreaker.java
@@ -97,9 +97,18 @@ public class CircuitBreaker<R> extends DelayablePolicy<CircuitBreaker<R>, R> {
    * Returns the delay before allowing another execution on the circuit. Defaults to 1 minute.
    *
    * @see #withDelay(Duration)
+   * @see #getRemainingDelay()
    */
   public Duration getDelay() {
     return delay;
+  }
+
+  /**
+   * When in the open state, returns the remaining delay until the circuit is half-closed and allows another execution,
+   * else returns {@code Duration.ZERO}.
+   */
+  public Duration getRemainingDelay() {
+    return state.get().getRemainingDelay();
   }
 
   /**

--- a/src/main/java/net/jodah/failsafe/internal/CircuitState.java
+++ b/src/main/java/net/jodah/failsafe/internal/CircuitState.java
@@ -20,6 +20,8 @@ import net.jodah.failsafe.ExecutionContext;
 import net.jodah.failsafe.internal.util.CircularBitSet;
 import net.jodah.failsafe.util.Ratio;
 
+import java.time.Duration;
+
 /**
  * The state of a circuit.
  *
@@ -33,6 +35,10 @@ public abstract class CircuitState {
   public abstract boolean allowsExecution();
 
   public abstract State getInternals();
+
+  public Duration getRemainingDelay() {
+    return Duration.ZERO;
+  }
 
   public int getFailureCount() {
     return bitSet.negatives();

--- a/src/main/java/net/jodah/failsafe/internal/OpenState.java
+++ b/src/main/java/net/jodah/failsafe/internal/OpenState.java
@@ -42,6 +42,13 @@ public class OpenState extends CircuitState {
   }
 
   @Override
+  public Duration getRemainingDelay() {
+    long elapsedTime = System.nanoTime() - startTime;
+    long remainingDelay = delayNanos - elapsedTime;
+    return Duration.ofNanos(Math.max(remainingDelay, 0));
+  }
+
+  @Override
   public State getInternals() {
     return State.OPEN;
   }

--- a/src/test/java/net/jodah/failsafe/internal/OpenStateTest.java
+++ b/src/test/java/net/jodah/failsafe/internal/OpenStateTest.java
@@ -41,4 +41,21 @@ public class OpenStateTest {
     assertTrue(state.allowsExecution());
     assertEquals(breaker.getState(), State.HALF_OPEN);
   }
+
+  public void testRemainingDelay() throws Throwable {
+    // Given
+    CircuitBreaker breaker = new CircuitBreaker().withDelay(Duration.ofSeconds(1));
+    OpenState state = new OpenState(breaker, new ClosedState(breaker, Testing.getInternals(breaker)), breaker.getDelay());
+
+
+    // When / Then
+    long remainingDelayMillis = state.getRemainingDelay().toMillis();
+    assertTrue(remainingDelayMillis < 1000);
+    assertTrue(remainingDelayMillis > 0);
+
+    Thread.sleep(110);
+    remainingDelayMillis = state.getRemainingDelay().toMillis();
+    assertTrue(remainingDelayMillis < 900);
+    assertTrue(remainingDelayMillis > 0);
+  }
 }

--- a/src/test/java/net/jodah/failsafe/internal/OpenStateTest.java
+++ b/src/test/java/net/jodah/failsafe/internal/OpenStateTest.java
@@ -47,7 +47,6 @@ public class OpenStateTest {
     CircuitBreaker breaker = new CircuitBreaker().withDelay(Duration.ofSeconds(1));
     OpenState state = new OpenState(breaker, new ClosedState(breaker, Testing.getInternals(breaker)), breaker.getDelay());
 
-
     // When / Then
     long remainingDelayMillis = state.getRemainingDelay().toMillis();
     assertTrue(remainingDelayMillis < 1000);
@@ -57,5 +56,18 @@ public class OpenStateTest {
     remainingDelayMillis = state.getRemainingDelay().toMillis();
     assertTrue(remainingDelayMillis < 900);
     assertTrue(remainingDelayMillis > 0);
+  }
+
+  public void testNoRemainingDelay() throws Throwable {
+    // Given
+    CircuitBreaker breaker = new CircuitBreaker().withDelay(Duration.ofMillis(10));
+    assertEquals(breaker.getRemainingDelay(), Duration.ZERO);
+
+    // When
+    OpenState state = new OpenState(breaker, new ClosedState(breaker, Testing.getInternals(breaker)), breaker.getDelay());
+    Thread.sleep(50);
+
+    // Then
+    assertEquals(state.getRemainingDelay().toMillis(), 0);
   }
 }


### PR DESCRIPTION
Fixes the second part of #188 by adding support for `CircuitBreaker.getRemainingDelay()`.

@whiskeysierra - Let me know if this is what you had in mind and feel free to review.