### PR TITLE
Timeout policy interruptable by default

### DIFF
--- a/src/main/java/net/jodah/failsafe/Timeout.java
+++ b/src/main/java/net/jodah/failsafe/Timeout.java
@@ -7,9 +7,9 @@ import net.jodah.failsafe.internal.util.Assert;
 import java.time.Duration;
 
 /**
- * A policy that fails an excecution with a {@link net.jodah.failsafe.TimeoutExceededException TimeoutExceededException}
+ * A policy that fails an execution with a {@link net.jodah.failsafe.TimeoutExceededException TimeoutExceededException}
  * if it exceeds a timeout. Uses a separate thread on the configured scheduler or the common pool to perform timeouts
- * checks.
+ * checks. Will interrupt execution by default, use withCancel to modify this behaviour.
  * <p>
  * The {@link Timeout#onFailure(CheckedConsumer)} and {@link Timeout#onSuccess(CheckedConsumer)} event handlers can be
  * used to handle a timeout being exceeded or not.
@@ -27,8 +27,8 @@ import java.time.Duration;
  */
 public class Timeout<R> extends PolicyListeners<Timeout<R>, R> implements Policy<R> {
   private final Duration timeout;
-  private volatile boolean cancellable;
-  private volatile boolean interruptable;
+  private volatile boolean cancellable = true;
+  private volatile boolean interruptable = true;
 
   private Timeout(Duration timeout) {
     this.timeout = timeout;

--- a/src/test/java/net/jodah/failsafe/AbstractFailsafeTest.java
+++ b/src/test/java/net/jodah/failsafe/AbstractFailsafeTest.java
@@ -320,7 +320,7 @@ public abstract class AbstractFailsafeTest {
   public void shouldTimeoutAndCancelAndInterrupt() throws Throwable {
     // Given
     RetryPolicy<Object> rp = new RetryPolicy<>().withMaxRetries(2);
-    Timeout<Object> timeout = Timeout.of(Duration.ofMillis(100)).withCancel(true).onFailure(e -> {
+    Timeout<Object> timeout = Timeout.of(Duration.ofMillis(100)).onFailure(e -> {
       waiter.assertTrue(e.getFailure() instanceof TimeoutExceededException);
       waiter.resume();
     });
@@ -348,11 +348,11 @@ public abstract class AbstractFailsafeTest {
   }
 
   /**
-   * Ensures that an interrupted execution should always have the interrupt flag cleared aferwards.
+   * Ensures that an interrupted execution should always have the interrupt flag cleared afterwards.
    */
   public void shouldHandleNonInterruptableExecution() throws Throwable {
     // Given
-    Timeout<Object> timeout = Timeout.of(Duration.ofMillis(1)).withCancel(true);
+    Timeout<Object> timeout = Timeout.of(Duration.ofMillis(1));
     CheckedSupplier supplier = () -> {
       try {
         Thread.sleep(1000);

--- a/src/test/java/net/jodah/failsafe/AsyncFailsafeTest.java
+++ b/src/test/java/net/jodah/failsafe/AsyncFailsafeTest.java
@@ -291,7 +291,7 @@ public class AsyncFailsafeTest extends AbstractFailsafeTest {
     // Given
     RetryPolicy<Boolean> rp = new RetryPolicy<Boolean>().withMaxRetries(2);
     Timeout<Boolean> timeout1 = Timeout.of(Duration.ofMillis(1000));
-    Timeout<Boolean> timeout2 = Timeout.<Boolean>of(Duration.ofMillis(200)).withCancel(true);
+    Timeout<Boolean> timeout2 = Timeout.<Boolean>of(Duration.ofMillis(200));
     AtomicReference<FailsafeFuture<Boolean>> futureRef = new AtomicReference<>();
     CountDownLatch futureLatch = new CountDownLatch(1);
 

--- a/src/test/java/net/jodah/failsafe/SyncFailsafeTest.java
+++ b/src/test/java/net/jodah/failsafe/SyncFailsafeTest.java
@@ -163,7 +163,7 @@ public class SyncFailsafeTest extends AbstractFailsafeTest {
     // Given
     RetryPolicy<Boolean> rp = new RetryPolicy<Boolean>().withMaxRetries(2);
     Timeout<Boolean> timeout1 = Timeout.of(Duration.ofMillis(1000));
-    Timeout<Boolean> timeout2 = Timeout.<Boolean>of(Duration.ofMillis(200)).withCancel(true);
+    Timeout<Boolean> timeout2 = Timeout.<Boolean>of(Duration.ofMillis(200));
 
     // When / Then
     assertThrows(() -> Failsafe.with(rp, timeout2, timeout1).onComplete(e -> {


### PR DESCRIPTION
Interruptable true as a more sensible default.

I think this might be more the expected behavior, I certainly was surprised that I need to set additional flags to get a useful timeout. When I define a timeout of 1s and an execution(rpc) takes 10s, getting a response after 10s that the computation timed out hardly introduces resiliency to the code. I think it might be more sensible to make the timeout policy interruptable and cancellable by default with ability to disable it for some reason. I would be interested about the reasoning behind this default.

If this is reasonable I can finish this PR, we would need some changes to the API.

Issue supporting this:
#209 
