### PR TITLE
Add non-wrapped exceptions to get()

### DIFF
--- a/src/main/java/net/jodah/failsafe/Execution.java
+++ b/src/main/java/net/jodah/failsafe/Execution.java
@@ -15,11 +15,11 @@
  */
 package net.jodah.failsafe;
 
-import net.jodah.failsafe.internal.util.Assert;
-import net.jodah.failsafe.internal.util.DelegatingScheduler;
-
 import java.util.Arrays;
 import java.util.function.Supplier;
+
+import net.jodah.failsafe.internal.util.Assert;
+import net.jodah.failsafe.internal.util.DelegatingScheduler;
 
 /**
  * Tracks executions and determines when an execution can be performed for a {@link RetryPolicy}.
@@ -127,6 +127,16 @@ public class Execution extends AbstractExecution {
       supplier = policyExecutor.supply(supplier, scheduler);
 
     ExecutionResult result = supplier.get();
+    completed = result.isComplete();
+    executor.handleComplete(result, this);
+    return result;
+  }
+  
+  <E extends Throwable> ExecutionResultWithException<E> executeSyncWithException(Supplier<ExecutionResultWithException<E>> supplier) {
+    for (PolicyExecutor<Policy<Object>> policyExecutor : policyExecutors)
+      supplier = policyExecutor.supplyWithException(supplier, scheduler);
+
+    ExecutionResultWithException<E> result = supplier.get();
     completed = result.isComplete();
     executor.handleComplete(result, this);
     return result;

--- a/src/main/java/net/jodah/failsafe/ExecutionResult.java
+++ b/src/main/java/net/jodah/failsafe/ExecutionResult.java
@@ -50,7 +50,7 @@ public class ExecutionResult {
     this(result, failure, false, 0, false, failure == null, failure == null);
   }
 
-  private ExecutionResult(Object result, Throwable failure, boolean nonResult, long waitNanos, boolean complete,
+  protected ExecutionResult(Object result, Throwable failure, boolean nonResult, long waitNanos, boolean complete,
     boolean success, Boolean successAll) {
     this.nonResult = nonResult;
     this.result = result;

--- a/src/main/java/net/jodah/failsafe/ExecutionResultWithException.java
+++ b/src/main/java/net/jodah/failsafe/ExecutionResultWithException.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package net.jodah.failsafe;
+
+import java.util.Objects;
+
+/**
+ * The result of an execution. Immutable.
+ * <p>
+ * Part of the Failsafe SPI.
+ *
+ * @author Jonathan Halterman
+ */
+public class ExecutionResultWithException<E extends Throwable> extends ExecutionResult {
+  public ExecutionResultWithException(Object result, E failure) {
+    this(result, failure, false, 0, false, failure == null, failure == null);
+  }
+
+  private ExecutionResultWithException(Object result, E failure, boolean nonResult, long waitNanos, boolean complete,
+    boolean success, Boolean successAll) {
+	  super(result, failure, nonResult, waitNanos, complete, success, successAll);
+  }
+
+  /**
+   * Returns a an ExecutionResult with the {@code result} set, {@code completed} true and {@code success} true.
+   */
+  public static <E extends Throwable> ExecutionResultWithException<E> successWithException(Object result) {
+    return new ExecutionResultWithException<>(result, null);
+  }
+
+  /**
+   * Returns a an ExecutionResult with the {@code failure} set, {@code completed} true and {@code success} false.
+   */
+  public static <E extends Throwable> ExecutionResultWithException<E> failureWithException(E failure) {
+    return new ExecutionResultWithException<>(null, failure, false, 0, true, false, false);
+  }
+
+  @SuppressWarnings("unchecked")
+  public E getFailure() {
+    return (E) super.getFailure();
+  }
+
+  /**
+   * Returns a copy of the ExecutionResult with a non-result, and completed and success set to true. Returns
+   * {@code this} if {@link #success} and {@link #result} are unchanged.
+   */
+  ExecutionResultWithException<E> withNonResult() {
+    return super.isSuccess() && super.getResult() == null && super.isNonResult() ?
+      this :
+      new ExecutionResultWithException<E>(null, null, true, super.getWaitNanos(), true, true, super.getSuccessAll());
+  }
+
+  /**
+   * Returns a copy of the ExecutionResult with the {@code result} value, and completed and success set to true. Returns
+   * {@code this} if {@link #success} and {@link #result} are unchanged.
+   */
+  public ExecutionResultWithException<E> withResult(Object result) {
+    return super.isSuccess() && ((super.getResult() == null && result == null) || (super.getResult() != null && super.getResult().equals(result))) ?
+      this :
+      new ExecutionResultWithException<>(result, null, super.isNonResult(), super.getWaitNanos(), true, true, super.getSuccessAll());
+  }
+
+  /**
+   * Returns a copy of the ExecutionResult with the value set to true, else this if nothing has changed.
+   */
+  @SuppressWarnings("unchecked")
+  public ExecutionResultWithException<E> withComplete() {
+    return super.isComplete() ? this : new ExecutionResultWithException<E>(super.getResult(), (E) super.getFailure(), super.isNonResult(), super.getWaitNanos(), true, super.isSuccess(), super.getSuccessAll());
+  }
+
+  /**
+   * Returns a copy of the ExecutionResult with the {@code completed} and {@code success} values.
+   */
+  @SuppressWarnings("unchecked")
+  ExecutionResultWithException<E> with(boolean completed, boolean success) {
+    return super.isComplete() == completed && super.isSuccess() == success ?
+      this :
+      new ExecutionResultWithException<E>(super.getResult(), (E) super.getFailure(), super.isNonResult(), super.getWaitNanos(), completed, success,
+        super.isSuccess() && super.getSuccessAll());
+  }
+
+  /**
+   * Returns a copy of the ExecutionResult with the {@code waitNanos}, {@code completed} and {@code success} values.
+   */
+  @SuppressWarnings("unchecked")
+  public ExecutionResultWithException<E> with(long waitNanos, boolean completed, boolean success) {
+    return super.getWaitNanos() == waitNanos && super.isComplete() == completed && super.isSuccess() == success ?
+      this :
+      new ExecutionResultWithException<E>(super.getResult(), (E) super.getFailure(), super.isNonResult(), waitNanos, completed, success,
+        super.isSuccess() && super.getSuccessAll());
+  }
+
+  @Override
+  public String toString() {
+    return "ExecutionResult[" + "result=" + super.getResult() + ", failure=" + super.getFailure() + ", nonResult=" + super.isNonResult()
+      + ", waitNanos=" + super.getWaitNanos() + ", complete=" + super.isComplete() + ", success=" + super.isSuccess() + ", successAll=" + super.getSuccessAll()
+      + ']';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o)
+      return true;
+    if (o == null || getClass() != o.getClass())
+      return false;
+    ExecutionResultWithException<E> that = (ExecutionResultWithException<E>) o;
+    return Objects.equals(super.getResult(), that.getResult()) && Objects.equals(super.getFailure(), that.getFailure());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.getResult(), super.getFailure());
+  }
+}

--- a/src/main/java/net/jodah/failsafe/Functions.java
+++ b/src/main/java/net/jodah/failsafe/Functions.java
@@ -66,6 +66,35 @@ final class Functions {
     };
   }
 
+  static <T, E extends Throwable> Supplier<ExecutionResultWithException<E>> getWithException(CheckedSupplierWithException<T, E> supplier, AbstractExecution execution) throws E {
+    return () -> {
+      ExecutionResultWithException<E> result;
+      Throwable throwable = null;
+      try {
+        execution.preExecute();
+        result = ExecutionResultWithException.successWithException(supplier.get());
+      } catch (Throwable t) {
+        throwable = t;
+        // this probably needs some extra code in case an unexpected Exception is thrown
+        result = ExecutionResultWithException.failureWithException((E) t);
+      } finally {
+        // Guard against race with Timeout interruption
+        synchronized (execution) {
+          execution.canInterrupt = false;
+          if (execution.interrupted)
+            // Clear interrupt flag if interruption was intended
+            Thread.interrupted();
+          else if (throwable instanceof InterruptedException)
+            // Set interrupt flag if interrupt occurred but was not intentional
+            Thread.currentThread().interrupt();
+        }
+      }
+
+      execution.record(result);
+      return result;
+    };
+  }
+
   /**
    * Returns a Supplier that pre-executes the {@code execution}, applies the {@code supplier}, records the result and
    * returns a promise containing the result.

--- a/src/main/java/net/jodah/failsafe/function/CheckedSupplierWithException.java
+++ b/src/main/java/net/jodah/failsafe/function/CheckedSupplierWithException.java
@@ -1,0 +1,6 @@
+package net.jodah.failsafe.function;
+
+@FunctionalInterface
+public interface CheckedSupplierWithException<T, E extends Throwable> {
+  T get() throws E;
+}

--- a/src/test/java/net/jodah/failsafe/functional/SupplierWithExceptionTest.java
+++ b/src/test/java/net/jodah/failsafe/functional/SupplierWithExceptionTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2016 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License
+ */
+package net.jodah.failsafe.functional;
+
+import java.io.IOException;
+
+import org.testng.annotations.Test;
+
+import net.jodah.failsafe.Failsafe;
+import net.jodah.failsafe.RetryPolicy;
+
+@Test
+public class SupplierWithExceptionTest {
+	@Test(expectedExceptions = IOException.class)
+	public void testCheckedException() throws IOException {
+		RetryPolicy<Object> retryPolicy = new RetryPolicy<>();
+
+		Failsafe.with(retryPolicy).getWithException(() -> {
+			throw new IOException();
+		});
+	}
+}


### PR DESCRIPTION
We talked about this a few days ago; basically, it allows you to properly catch an `Exception` thrown from code you call in a lambda, like so:

```java
public void testCheckedException() throws IOException {
	RetryPolicy<Object> retryPolicy = new RetryPolicy<>();

	Failsafe.with(retryPolicy).getWithException(() -> {
		throw new IOException();
	});
}
```

or

```java
RetryPolicy<Object> retryPolicy = new RetryPolicy<>();

try {
	Failsafe.with(retryPolicy).getWithException(() -> {
		throw new IOException();
	});
} catch (IOException e) {
	e.printStackTrace(); // this is horrible practice
}
```

Obviously the code is not intended to be accepted like this, it's just a POC.