### PR TITLE
Upgrade to netty-all 4.1.51.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-all</artifactId>
-      <version>4.0.43.Final</version>
+      <version>4.1.51.Final</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
The update netty-all ver 4.1.50 includes both security fixes and AArch64 performance improvements
Refer release notes for detail: https://netty.io/news/2020/05/13/4-1-50-Final.html

Signed-off-by: odidev <odidev@puresoftware.com>